### PR TITLE
Partial solution for https

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,17 +7,17 @@
     %meta{:name => "viewport", :content => "width=800, user-scalable=no"}
     / HTML5 shim, for IE6-8 support of HTML5 elements
     /[if lt IE 9]
-      = javascript_include_tag "http://html5shim.googlecode.com/svn/trunk/html5.js"
-    = javascript_include_tag "http://maps.google.com/maps/api/js?sensor=false&language=#{I18n.locale}"
-    = javascript_include_tag "http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"
-    = javascript_include_tag "http://ajax.googleapis.com/ajax/libs/jqueryui/1/jquery-ui.min.js"
-    = javascript_include_tag "http://twitter.github.com/bootstrap/1.4.0/bootstrap-twipsy.min.js"
-    = javascript_include_tag "http://twitter.github.com/bootstrap/1.4.0/bootstrap-alerts.min.js"
-    = javascript_include_tag "http://twitter.github.com/bootstrap/1.4.0/bootstrap-modal.min.js"
+      = javascript_include_tag "//html5shim.googlecode.com/svn/trunk/html5.js"
+    = javascript_include_tag "//maps.google.com/maps/api/js?sensor=false&language=#{I18n.locale}"
+    = javascript_include_tag "//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"
+    = javascript_include_tag "//ajax.googleapis.com/ajax/libs/jqueryui/1/jquery-ui.min.js"
+    = javascript_include_tag "//twitter.github.com/bootstrap/1.4.0/bootstrap-twipsy.min.js"
+    = javascript_include_tag "//twitter.github.com/bootstrap/1.4.0/bootstrap-alerts.min.js"
+    = javascript_include_tag "//twitter.github.com/bootstrap/1.4.0/bootstrap-modal.min.js"
     = javascript_include_tag javascript_path
     %script{:type => "text/javascript"}
       var _gaq=_gaq||[];_gaq.push(["_setAccount","UA-32915849-3"]),_gaq.push(["_setDomainName","sirens.honolulu.gov"]),_gaq.push(["_trackPageview"]),function(){var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"==document.location.protocol?"https://ssl":"http://www")+".google-analytics.com/ga.js";var b=document.getElementsByTagName("script")[0];b.parentNode.insertBefore(a,b)}();
-    = stylesheet_link_tag "http://twitter.github.com/bootstrap/1.4.0/bootstrap.min.css"
+    = stylesheet_link_tag "//twitter.github.com/bootstrap/1.4.0/bootstrap.min.css"
     = stylesheet_link_tag "screen"
     /[if lt IE 8]
       = stylesheet_link_tag "ie6"


### PR DESCRIPTION
Fixes issue for Google Maps and jQuery, but not Bootstrap. Could either find a site that hosts Bootstrap 1.4 files and supports SSL or upgrade to Bootstrap 2.x and use BootstrapCDN, which does support SSL.
