### PR TITLE
Remove accidental reference to last_adopted_at

### DIFF
--- a/app/controllers/things_controller.rb
+++ b/app/controllers/things_controller.rb
@@ -30,7 +30,6 @@ class ThingsController < ApplicationController
         @thing.update_attributes({:name=>params[:thing][:name]})
       end
       if !@thing.adopted_by(params[:thing][:user_id])
-        current_user.update_attributes(:last_adoption_at => Time.current)
         @thing.users << current_user
       end
     end


### PR DESCRIPTION
In my first attempt to track users that should be subscribed to the email list, I was updating a column with the time they last adopted a drain. I changed this to track when we last subscribed them, but I forgot to remove the update of last_adopted_at. This simple fix corrects that oversight.
