### PR TITLE
fixes #32 Adds PWA contact info

### DIFF
--- a/app/views/main/index.html.haml
+++ b/app/views/main/index.html.haml
@@ -21,11 +21,15 @@
         %a{:href => "http://www2.oaklandnet.com/"}
           = image_tag "logos/citytree_green_small.jpg", :width => '90px', :alt => t("sponsors.city"), :title => t("sponsors.city")
 
-
       #feedback
         %br
         %br
         %br
+        %p
+          To report a problem to the City of Oakland Public Works Agency, call 510-615-5566, email
+          %a{:href => URI.escape("mailto:pwacallcenter@oaklandnet.com")}pwacallcenter@oaklandnet.com
+          or visit
+          %a{:href => "http://www.seeclickfix.com/oakland"}www.seeclickfix.com/oakland.
         %p
           %a{:href => URI.escape("mailto:nneditch@oaklandnet.com?subject=#{t("titles.main", :thing => t("defaults.thing").titleize)} #{t("links.feedback").titleize}")}
             = t("links.feedback")


### PR DESCRIPTION
It's not beautiful but the contact info for the PWA is no in the requested spot.
