### PR TITLE
fixes #34 Buttons at top right to switch between road map and satellite view

### DIFF
--- a/app/views/javascripts/main.js.erb
+++ b/app/views/javascripts/main.js.erb
@@ -44,7 +44,10 @@ function load() {
   var mapOptions = {
     center: center,
     disableDoubleClickZoom: false,
-    mapTypeControl: false,
+    mapTypeControl: true,
+    mapTypeControlOptions: {
+      mapTypes: [google.maps.MapTypeId.ROADMAP, google.maps.MapTypeId.SATELLITE]
+    },
     mapTypeId: google.maps.MapTypeId.ROADMAP,
     maxZoom: 19,
     minZoom: 16,


### PR DESCRIPTION
Someone may want to style the buttons a little more nicely, but they work.
