### PR TITLE
Increasing secret token for dev env to 30 chars to keep Rails happy

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-AdoptAThing::Application.config.secret_token = ENV['RAILS_SECRET_TOKEN'].nil? ? 'CHANGE ME' : ENV['RAILS_SECRET_TOKEN']
+AdoptAThing::Application.config.secret_token = ENV['RAILS_SECRET_TOKEN'].nil? ? ('x' * 30) : ENV['RAILS_SECRET_TOKEN']


### PR DESCRIPTION
Increasing secret token for dev env to 30 chars to keep Rails happy
